### PR TITLE
Fix repo directory in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ We recommend that you use pyenv, because (1) CoCrawler requires Python
 
 ```
 git clone https://github.com/cocrawler/cocrawler.git
-cd cocrawl
+cd cocrawler
 make init  # will install requirements using pip
 make pytest
 make test_coverage


### PR DESCRIPTION
The `cocrawler` directory is created with the `git clone` if no new directory name is specified. Alternatively `git clone https://github.com/cocrawler/cocrawler.git cocrawl` could be used as the first line the match up with the subsequent instructions but the change in this PR is a bit simpler.